### PR TITLE
Update README.mkd of ettu by changing 'go get' to 'go install'

### DIFF
--- a/ettu/README.mkd
+++ b/ettu/README.mkd
@@ -9,7 +9,7 @@ it though.
 ## Install
 
 ```
-go get -u github.com/tomnomnom/hacks/ettu
+go install -v github.com/tomnomnom/hacks/ettu@latest
 ```
 
 ## Usage


### PR DESCRIPTION
when installing using the command
'go get -u github.com/tomnomnom/hacks/ettu'
we receive the message 
'go get is no longer supported outside a module. To build and install a command, use go install...' This change applies this suggestion, using 'go install' instead of 'go get'